### PR TITLE
update gitignore with double-star syntax

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,15 +38,13 @@ doc/_build
 *.profile
 
 # out/old
-*/old/*
-*/out/*
-LOTlib/Examples/NumberGame/GrammarInference/Run/out/*
-LOTlib/Examples/FormalLanguageTheory/out/*
-
+**/old/*
+**/out/*
 
 # zips
 *.zip
 
-# idea folder
-/.idea/*
-.idea/
+# idea file/folder
+**/.idea/*
+**/idea/*
+*.idea


### PR DESCRIPTION
This is a pretty simple change to allow "idea" and "old" files to be detected anywhere in the repository. The old syntax only recognized them in a few specific places.